### PR TITLE
ENV: Remove duplicate settings

### DIFF
--- a/wpstarter/templates/.env.example
+++ b/wpstarter/templates/.env.example
@@ -227,8 +227,6 @@ WP_HOME=
 #WP_PROXY_USERNAME
 #WP_PROXY_PASSWORD
 #WP_PROXY_BYPASS_HOSTS
-#WP_ACCESSIBLE_HOSTS
-#WP_HTTP_BLOCK_EXTERNAL
 
 
 #--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
`WP_ACCESSIBLE_HOSTS` and `WP_HTTP_BLOCK_EXTERNAL` appeared under the Security and Proxy headings.