### PR TITLE
Fix flawed logic when checking for an 'extra' entry in the `composer.json` file.

### DIFF
--- a/wpstarter/src/MuLoader/MuLoader.php
+++ b/wpstarter/src/MuLoader/MuLoader.php
@@ -207,8 +207,8 @@ class MuLoader
     {
         // check "extra.wordpress-plugin-main-file" in composer.json
         $main = isset($json['extra']) && isset($json['extra'][self::EXTRA_KEY]) ?
-            $json['extra'][self::EXTRA_KEY]
-            : str_replace('\\', '/', $json['extra'][self::EXTRA_KEY]);
+            str_replace('\\', '/', $json['extra'][self::EXTRA_KEY])
+            : false;
         if ($main) {
             $path = "{$basedir}/{$main}";
             $this->plugins[] = $path;


### PR DESCRIPTION
With this PR, I assumed that the `str_replace` was meant to target the case where the `extra` entry in the `composer.json` file actually exists. So I moved this operation to the middle section of the ternary operator, and added a simple `false` as the final section, to avoid that the subsequent code gets executed when the `extra` entry does not exist.

Resolves #18