### PR TITLE
Use https for wpackagist in docs

### DIFF
--- a/docs/complete-example.md
+++ b/docs/complete-example.md
@@ -19,7 +19,7 @@ all WP Starter configuration. Explanation is provided below in this page.
     "repositories": [
         {
             "type": "composer",
-            "url": "http://wpackagist.org"
+            "url": "https://wpackagist.org"
         },
         {
             "type": "vcs",
@@ -120,7 +120,7 @@ This is [a Composer setting](https://getcomposer.org/doc/04-schema.md#repositori
 
 I've added 3 entries.
 
-The first is [wpackagist](http://wpackagist.org). It is a mirror of the official WordPress plugin and theme directories as a Composer repository. In short, it allows to install all the plugins and themes available in official WordPress repository as Composer packages, no matter if they *natively* support Composer or not.
+The first is [wpackagist](https://wpackagist.org). It is a mirror of the official WordPress plugin and theme directories as a Composer repository. In short, it allows to install all the plugins and themes available in official WordPress repository as Composer packages, no matter if they *natively* support Composer or not.
 
 The other two repositories are Gist of mine. They were created to show in this example how to use custom packages to collect files that you want to share among WP Starter projects. More on this below.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -30,7 +30,7 @@ That `composer.json` file should contain:
     "repositories": [
         {
             "type": "composer",
-            "url": "http://wpackagist.org"
+            "url": "https://wpackagist.org"
         }
     ],
     "require": {
@@ -53,7 +53,7 @@ This is a minimal example, but is possible to add any plugin or theme.
 
 For plugins and themes that support Composer natively, it is possible to just add their package name to the require object.
 
-For plugins and themes that do not support Composer natively, but are available in WordPress repository (like WP Super Cache in the example) is possible to use packages provided by [wpackagist](http://wpackagist.org). To do that, wpackagist has to be added to `"repositories"` setting as shown above.
+For plugins and themes that do not support Composer natively, but are available in WordPress repository (like WP Super Cache in the example) is possible to use packages provided by [wpackagist](https://wpackagist.org). To do that, wpackagist has to be added to `"repositories"` setting as shown above.
 
 The `config.vendor-dir` setting is optional. In the example above is used to have the vendor folder placed inside `wp-content` folder so that at the end of the installation the folder structure will be something like:
 

--- a/docs/what.md
+++ b/docs/what.md
@@ -27,7 +27,7 @@ with its dozen of thousands of installations.
 ## Themes & Plugins Packages
 
 The second issue that arises using WordPress with Composer is the ability to use WordPress plugins and themes as Composer packages.
-This issue has been resolved thank to the work [outlandish](http://outlandish.com/) did creating [wpackagist](http://wpackagist.org/).
+This issue has been resolved thank to the work [outlandish](http://outlandish.com/) did creating [wpackagist](https://wpackagist.org/).
 
 It is a mirror of the WordPress plugin and theme directories as a Composer repository.
 


### PR DESCRIPTION
As in 19c79b812 this pull request simply updates all the URLs to `wpackagist.org` in the documentation. That avoids »insecure connection« errors in composer for a user, when following the documentation strictly (c&p).