### PR TITLE
Fix for PHP Warning as per issue #36

### DIFF
--- a/wpstarter/src/MuLoader/PluginAsMuLoader.php
+++ b/wpstarter/src/MuLoader/PluginAsMuLoader.php
@@ -62,7 +62,7 @@ class PluginAsMuLoader
     public function install()
     {
         if (! empty($this->plugins)) {
-            $this->uninstall = get_option('uninstall_plugins', array());
+            $this->uninstall = (array) get_option('uninstall_plugins', array());
             array_walk($this->plugins, array($this, 'installPlugin'));
         }
     }


### PR DESCRIPTION
Cast whatever we get from `get_option(uninstall_plugins)` to an array, to avoid throwing a warning in line 79. Resolves #36