### PR TITLE
fix(tmpl) Fix variable syntax for env file, see #38

### DIFF
--- a/wpstarter/templates/.env.example
+++ b/wpstarter/templates/.env.example
@@ -77,7 +77,7 @@ WP_HOME=
 #PATH_CURRENT_SITE=/
 #SITE_ID_CURRENT_SITE=1
 #BLOG_ID_CURRENT_SITE=1
-#NOBLOGREDIRECT={$WP_SITEURL}
+#NOBLOGREDIRECT=${WP_SITEURL}
 #UPLOADBLOGSDIR=blogs.dir
 #UPLOADS=files
 #BLOGUPLOADDIR=files
@@ -111,11 +111,11 @@ WP_HOME=
 #--------------------------------------------------------------------------------------------------#
 #WP_SITEURL
 #WP_CONTENT_DIR=./../wp-content
-#WP_CONTENT_URL={$WP_SITEURL}/wp-content
-#WP_PLUGIN_DIR={$WP_CONTENT_DIR}/plugins
-#WP_PLUGIN_URL={$WP_CONTENT_URL}/plugins
-#WPMU_PLUGIN_DIR={$WP_CONTENT_DIR}/mu-plugins
-#WPMU_PLUGIN_URL={$WP_CONTENT_URL}/mu-plugins
+#WP_CONTENT_URL=${WP_SITEURL}/wp-content
+#WP_PLUGIN_DIR=${WP_CONTENT_DIR}/plugins
+#WP_PLUGIN_URL=${WP_CONTENT_URL}/plugins
+#WPMU_PLUGIN_DIR=${WP_CONTENT_DIR}/mu-plugins
+#WPMU_PLUGIN_URL=${WP_CONTENT_URL}/mu-plugins
 #WP_TEMP_DIR=tmp
 
 
@@ -206,7 +206,7 @@ WP_HOME=
 #--------------------------------------------------------------------------------------------------#
 #                                            LANGUAGES                                             #
 #--------------------------------------------------------------------------------------------------#
-#WP_LANG_DIR={$WP_CONTENT_DIR}/tmp
+#WP_LANG_DIR=${WP_CONTENT_DIR}/tmp
 
 
 #--------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
Fixes the Bash nested variable syntax for the `.env.example` file.