### PR TITLE
Place wp-cli.yml in project root folder #33

### DIFF
--- a/wpstarter/src/Setup/Steps/WPCliStep.php
+++ b/wpstarter/src/Setup/Steps/WPCliStep.php
@@ -54,7 +54,7 @@ class WPCliStep implements FileStepInterface, BlockingStepInterface
 	 */
 	public function targetPath( ArrayAccess $paths )
 	{
-		return rtrim( "{$paths['root']}/{$paths['wp']}", "/" )."/wp-cli.yml";
+		return rtrim( $paths['root'], "/" )."/wp-cli.yml";
 	}
 
 	/**
@@ -77,9 +77,9 @@ class WPCliStep implements FileStepInterface, BlockingStepInterface
 	 */
 	public function run( ArrayAccess $paths )
 	{
-		$root        = rtrim( $paths['root'], '/' );
+		$wp_install_path = rtrim( "{$paths['root']}/{$paths['wp']}", '/' );
 
-		$this->vars  = array( 'WP_INSTALL_PATH' => $root, );
+		$this->vars  = array( 'WP_INSTALL_PATH' => $wp_install_path, );
 		$build       = $this->builder->build(
 			$paths,
 			'wp-cli.yml.example',


### PR DESCRIPTION
According to the discussin in #33 this commit places the
wp-cli.yml to the project root folder. It also fixes the
`path` value inside to the WordPress install path.