### PR TITLE
Define WP_CONTENT_URL only on single site #48

### DIFF
--- a/wpstarter/templates/wp-config.example
+++ b/wpstarter/templates/wp-config.example
@@ -136,7 +136,9 @@ defined('WP_SITEURL')     or define('WP_SITEURL',     rtrim(WP_HOME, '/').'/{{{W
  */
 if (realpath({{{WP_CONTENT_PATH}}}) !== realpath(ABSPATH.'/wp-content')) {
     defined('WP_CONTENT_DIR') or define('WP_CONTENT_DIR', realpath({{{WP_CONTENT_PATH}}}));
-    defined('WP_CONTENT_URL') or define('WP_CONTENT_URL', rtrim(WP_HOME, '/').'/{{{WP_CONTENT_URL}}}');
+    if ( ! defined('MULTISITE' ) || ! MULTISITE ) {
+        defined('WP_CONTENT_URL') or define('WP_CONTENT_URL', rtrim(WP_HOME, '/').'/{{{WP_CONTENT_URL}}}');
+    }
 }
 
 /**


### PR DESCRIPTION
Defining WP_CONTENT_URL on multisite can cause cross origin
issues under certain conditions. See #48