### PR TITLE
Note about --prefer-source

### DIFF
--- a/docs/how.md
+++ b/docs/how.md
@@ -8,6 +8,8 @@ The WP Starter flow starts with a `composer.json` file and ends with a fully wor
 
 Only two words sit in-between these two states: `composer install` typed into a console.
 
+If you're installing locally, and want to try and pull the Git history down where possible, so you can make improvements, use `composer install --prefer-source` instead.
+
 WP Starter uses a [Composer `post-install-cmd` script](https://getcomposer.org/doc/articles/scripts.md). This script is run by Composer after all packages have been installed and performs some operations that configure the WordPress site that has just been installed.
 
 ## The "Steps"


### PR DESCRIPTION
This is as much about starting a discussion about this note, than the specific wording I've gone for.

My use case is this:
 * I have got a `composer.json` that includes WPStarter and a load of plugins from wpackagist, [SatisPress](https://github.com/blazersix/satispress) install and private repos.
* When installing locally, I'd like to have the `.git` directories pulled down too, so I can see and add to the Git history as I make further changes to our plugins and theme in the private repos. I believe the `--prefer-source` flag is what's needed here, instead of manually having to delete what composer installed and manually setting up a clone from an individual repo for each of our custom plugins (OK, yes, this is what I was doing...)
* When installing for production, I want the default (`--prefer-dist`) to be used for all plugins and packages, so no change in Composer's [`preferred-install`](https://getcomposer.org/doc/06-config.md#preferred-install) is needed.

There's no change to behaviour here - just a note that would have saved me many hours of setting up local environments from a site `composer.json` that was written for production.

Aside: I think [composer-merge-plugin](https://github.com/wikimedia/composer-merge-plugin) would also be a solution i.e. try and merge in something like a `composer.local.json` which has an `extra->preferred-install` key to just pull in the `.git` for specified repos. I've yet to investigate this.