### PR TITLE
Local code standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[wp-config.example,index.example]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,11 @@
         "vlucas/phpdotenv": "~2.0",
         "johnpbloch/wordpress": ">=4.2"
     },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.0",
+        "wimg/php-compatibility": "^8.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2"
+    },
     "replace": {
         "wecodemore/wp-composer-config": "*"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="WPStarter">
+    <description>The code standard for WPStarter package.</description>
+    <file>wpstarter/src/</file>
+    <arg value="sp"/>
+    <arg name="extensions" value="php"/>
+    <arg name="report" value="full"/>
+    <arg name="report" value="summary"/>
+    <arg name="report" value="source"/>
+    <rule ref="PSR2"/>
+    <rule ref="PHPCompatibility"/>
+    <config name="testVersion" value="5.3-"/>
+</ruleset>

--- a/wpstarter/src/Env/Env.php
+++ b/wpstarter/src/Env/Env.php
@@ -252,14 +252,14 @@ final class Env
                     case in_array($var, self::$isBool, true):
                         $values[$var] = (bool) filter_var($value, FILTER_VALIDATE_BOOLEAN);
                         break;
-                    case in_array($var, self::$isBoolOrInt, true) :
+                    case in_array($var, self::$isBoolOrInt, true):
                         if (is_numeric($value)) {
                             $values[$var] = (int) $value;
                             break;
                         }
                         $values[$var] = (bool) filter_var($value, FILTER_VALIDATE_BOOLEAN);
                         break;
-                    case in_array($var, self::$isMod, true) :
+                    case in_array($var, self::$isMod, true):
                         $check = $this->checkMod($value);
                         is_null($check) or $values[$var] = $check;
                         break;

--- a/wpstarter/src/Helpers.php
+++ b/wpstarter/src/Helpers.php
@@ -57,13 +57,11 @@ class Helpers
     public static function addHook($hook, $callable, $priority = 10, $argsNum = 1)
     {
         // sanity check
-        if (
-            !is_callable($callable)
+        if (!is_callable($callable)
             || !is_scalar($hook)
             || !$hook
             || !is_numeric($priority)
             || !is_int($argsNum)) {
-
             return;
         }
 
@@ -75,8 +73,7 @@ class Helpers
             return;
         }
 
-        if (
-            defined(ABSPATH)
+        if (defined(ABSPATH)
             && is_file(ABSPATH.'wp-includes/class-wp-hook.php')
             && is_file(ABSPATH.'wp-includes/plugin.php')
         ) {

--- a/wpstarter/src/MuLoader/MuLoader.php
+++ b/wpstarter/src/MuLoader/MuLoader.php
@@ -106,9 +106,8 @@ class MuLoader
      */
     private function loadPlugin($key, $file, $refresh, $transient)
     {
-        if (
-            is_readable($file)
-            && strtolower( (string) pathinfo($file, PATHINFO_EXTENSION)) === 'php'
+        if (is_readable($file)
+            && strtolower((string) pathinfo($file, PATHINFO_EXTENSION)) === 'php'
         ) {
             wp_register_plugin_realpath($file);
             if (in_array($file, $this->regular, true)) {
@@ -232,8 +231,7 @@ class MuLoader
         static $show;
         if ($type === 'mustuse') {
             $show = $bool;                          // does user want to show mustuse plugins?
-        } elseif (
-            $type === 'dropins'                     // dropins are checked after mustuse
+        } elseif ($type === 'dropins'                     // dropins are checked after mustuse
             && $show                                // if user want show mustuse plugins
             && $screen->base === $check             // we are in right screen
             && current_user_can('activate_plugins') // and user has right capabilities

--- a/wpstarter/src/MuLoader/PluginAsMuLoader.php
+++ b/wpstarter/src/MuLoader/PluginAsMuLoader.php
@@ -74,8 +74,7 @@ class PluginAsMuLoader
     {
         $basename = plugin_basename($plugin);
         $isUninstall = array_key_exists($this->uninstall, $basename);
-        if (
-            has_action("deactivate_{$basename}")
+        if (has_action("deactivate_{$basename}")
             || file_exists(dirname($plugin).'/uninstall.php')
             || $isUninstall
         ) {

--- a/wpstarter/src/Setup/Steps/CheckPathStep.php
+++ b/wpstarter/src/Setup/Steps/CheckPathStep.php
@@ -67,8 +67,7 @@ class CheckPathStep implements BlockingStepInterface, PostProcessStepInterface
 
             return self::ERROR;
         }
-        if (
-            $paths['wp-content']
+        if ($paths['wp-content']
             && $paths['wp-parent']
             && strpos(trim($paths['wp-content'], '\\/'), trim($paths['wp-parent'], '\\/')) !== 0
         ) {

--- a/wpstarter/src/Setup/Steps/DropinsStep.php
+++ b/wpstarter/src/Setup/Steps/DropinsStep.php
@@ -230,7 +230,6 @@ class DropinsStep implements StepInterface
                     'Do you want to proceed with it anyway?',
                 );
                 break;
-
         }
 
         return $this->io->ask($lines, false);

--- a/wpstarter/src/Setup/Steps/WPCliStep.php
+++ b/wpstarter/src/Setup/Steps/WPCliStep.php
@@ -20,100 +20,100 @@ use WCM\WPStarter\Setup\FileBuilder;
  */
 class WPCliStep implements FileStepInterface, BlockingStepInterface
 {
-	/**
-	 * @var \WCM\WPStarter\Setup\FileBuilder
-	 */
-	private $builder;
+    /**
+     * @var \WCM\WPStarter\Setup\FileBuilder
+     */
+    private $builder;
 
-	/**
-	 * @var array
-	 */
-	private $vars;
+    /**
+     * @var array
+     */
+    private $vars;
 
-	/**
-	 * @var string
-	 */
-	private $error = '';
+    /**
+     * @var string
+     */
+    private $error = '';
 
-	/**
-	 * @param \WCM\WPStarter\Setup\FileBuilder $builder
-	 */
-	public function __construct( FileBuilder $builder )
-	{
-		$this->builder = $builder;
-	}
+    /**
+     * @param \WCM\WPStarter\Setup\FileBuilder $builder
+     */
+    public function __construct(FileBuilder $builder)
+    {
+        $this->builder = $builder;
+    }
 
-	/**
-	 * Returns the target path of the file the step will create.
-	 *
-	 * @param  \ArrayAccess $paths
-	 * @return string
-	 */
-	public function targetPath( ArrayAccess $paths )
-	{
-		return rtrim( $paths['root'], "/" )."/wp-cli.yml";
-	}
+    /**
+     * Returns the target path of the file the step will create.
+     *
+     * @param  \ArrayAccess $paths
+     * @return string
+     */
+    public function targetPath(ArrayAccess $paths)
+    {
+        return rtrim($paths['root'], "/")."/wp-cli.yml";
+    }
 
-	/**
-	 * Return true if the step is allowed, i.e. the run method have to be called or not
-	 *
-	 * @param  \WCM\WPStarter\Setup\Config $config
-	 * @param  \ArrayAccess                $paths
-	 * @return bool
-	 */
-	public function allowed( Config $config, ArrayAccess $paths )
-	{
-		return true;
-	}
+    /**
+     * Return true if the step is allowed, i.e. the run method have to be called or not
+     *
+     * @param  \WCM\WPStarter\Setup\Config $config
+     * @param  \ArrayAccess                $paths
+     * @return bool
+     */
+    public function allowed(Config $config, ArrayAccess $paths)
+    {
+        return true;
+    }
 
-	/**
-	 * Process the step.
-	 *
-	 * @param  \ArrayAccess $paths Have to return one of the step constants.
-	 * @return int
-	 */
-	public function run( ArrayAccess $paths )
-	{
+    /**
+     * Process the step.
+     *
+     * @param  \ArrayAccess $paths Have to return one of the step constants.
+     * @return int
+     */
+    public function run(ArrayAccess $paths)
+    {
         // wp-cli.yml is stored in root (see targetPath()) so we can use relative path to root
-        $wp_install_path = rtrim( "./{$paths['wp']}", '/' );
+        $wp_install_path = rtrim("./{$paths['wp']}", '/');
 
-		$this->vars  = array( 'WP_INSTALL_PATH' => $wp_install_path, );
-		$build       = $this->builder->build(
-			$paths,
-			'wp-cli.yml.example',
-			$this->vars
-		);
+        $this->vars  = array( 'WP_INSTALL_PATH' => $wp_install_path, );
+        $build       = $this->builder->build(
+            $paths,
+            'wp-cli.yml.example',
+            $this->vars
+        );
 
-		if ( ! $this->builder->save(
-			$build,
-			dirname( $this->targetPath( $paths ) ),
-			'wp-cli.yml'
-		) ) {
-			$this->error = 'Error while creating wp-cli.yml';
+        if (! $this->builder->save(
+            $build,
+            dirname($this->targetPath($paths)),
+            'wp-cli.yml'
+        ) ) {
+            $this->error = 'Error while creating wp-cli.yml';
 
-			return self::ERROR;
-		}
+            return self::ERROR;
+        }
 
-		return self::SUCCESS;
-	}
+        return self::SUCCESS;
+    }
 
-	/**
-	 * Return error message if any.
-	 *
-	 * @return string
-	 */
-	public function error()
-	{
-		return $this->error;
-	}
+    /**
+     * Return error message if any.
+     *
+     * @return string
+     */
+    public function error()
+    {
+        return $this->error;
+    }
 
-	/**
-	 * Return success message if any.
-	 *
-	 * @return string
-	 */
-	public function success()
-	{
-		return '<comment>wp-cli.yml</comment> saved successfully.';
-	}
+    /**
+     * Return success message if any.
+     *
+     * @return string
+     */
+    public function success()
+    {
+        return '<comment>wp-cli.yml</comment> saved successfully.';
+    }
 }

--- a/wpstarter/src/Setup/UrlDownloader.php
+++ b/wpstarter/src/Setup/UrlDownloader.php
@@ -121,8 +121,7 @@ class UrlDownloader
         $info = curl_getinfo($ch);
         $code = (int) $info['http_code'];
         $wanted = $json ? 'application/json' : 'text/plain';
-        if (
-            !empty($response)
+        if (!empty($response)
             && empty($error)
             && $code === 200
             && $this->contentType($info['content_type']) === $wanted


### PR DESCRIPTION
* Add `.editorconfig`
* Add local PHP_CodeSniffer, installer, and standard 
  * This package should have code that follows PSR-2. Installing PHP_CodeSniffer allows us to check for that.
  * We also state that this package should work for PHP 5.3 and above, so the PHPCompatibility package is a PHPCS standard that allows us to check that we're not using syntax from above PHP 5.3.
  * The phpcodesniffer-composer-installer package is a Composer plugin that allows for automatic registering of code standards outside of the PHPCS core.
* CS: Auto-fix src/ code to PSR-2 using `phpcbf`
  * The main difference here seems to be with multi-part conditionals starting on the opening line, instead of the next line down. 

![screenshot 2017-09-14 12 56 58](https://user-images.githubusercontent.com/88371/30428639-3ba7dd2a-994c-11e7-9e81-6f3f2bade99e.png)

Not addressed, is the desire to have WPCS for the `templates/index.example` and `templates/wp-config.example` files.


