### PR TITLE
Ignore dirs only on the top level

### DIFF
--- a/wpstarter/src/Setup.php
+++ b/wpstarter/src/Setup.php
@@ -155,10 +155,10 @@ class Setup
             ? $extra['wordpress-install-dir']
             : 'wordpress';
         $wpFullDir = "{$cwd}/{$wpInstallDir}";
-        $wpSubdir = $this->subdir($cwd, $wpFullDir);
+        $wpSubdir = '/' . $this->subdir($cwd, $wpFullDir);
         $wpContent = isset($extra['wordpress-content-dir'])
-            ? $this->subdir($cwd, $cwd.'/'.$extra['wordpress-content-dir'])
-            : 'wp-content';
+            ? '/' . $this->subdir($cwd, $cwd.'/'.$extra['wordpress-content-dir'])
+            : '/wp-content';
 
         return new ArrayObject($this->normalisePaths(array(
             'root' => $cwd,


### PR DESCRIPTION
```ini
### WP Starter
.env
/wp-config.php
/wp/
/wp-content/
```

Ignoring `.env` in subdirs are OK.