### PR TITLE
fix: success/error block console output

### DIFF
--- a/src/Util/Io.php
+++ b/src/Util/Io.php
@@ -291,7 +291,7 @@ class Io
      */
     public function writeColorBlock(string $color, string ...$lines): bool
     {
-        return $this->writeBlock($color, strtolower($color) !== 'red', ...$lines);
+        return $this->writeBlock($color, strtolower($color) === 'red', ...$lines);
     }
 
     /**
@@ -316,7 +316,7 @@ class Io
         string ...$lines
     ): bool {
 
-        $frontground = $isError ? 'white;option=bold' : 'black';
+        $frontground = $isError ? 'white;options=bold' : 'black';
 
         $block = self::createBlock("<bg={$background};fg={$frontground}>  ", '  </>', ...$lines);
 


### PR DESCRIPTION
## Description
- Success block was displaying console formatting code instead of a green colored block
- Error block was not being displayed in bold in the console

### Bug fixes (non-breaking change which fixes an issue)
- `WeCodeMore\WpStarter\Util::writeColorBlock` was checking if `$color !== 'red`  when it needs to pass the result of the expression as the `$isError` argument to `WeCodeMore\WpStarter\Util::writeBlock`.
- `WeCodeMore\WpStarter\Util::writeBlock` was adding `option=bold` to the console formatting code, but the correct form is `options=bold`
