### PR TITLE
Remove full stop from MU plugins loader name

### DIFF
--- a/templates/wpstarter-mu-loader.php
+++ b/templates/wpstarter-mu-loader.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 /**
- * Plugin Name: WP Starter MU plugins loader.
+ * Plugin Name: WP Starter MU plugins loader
  * Description: MU plugins loaded: {{{MU_PLUGINS_LIST}}}.
  */
 


### PR DESCRIPTION
## Description
Remove full stop from MU plugins loader name. Plugin names should not end with a dot.

## How has this been tested?
Not, because no logic changes.

## Types of changes
What types of changes does your code introduce?

### Bug fixes (non-breaking change which fixes an issue)
 
## Issues
None.

## Checklist:
- [ ] My code is tested
- [ ] My code follows the project code style
- [ ] My code has documentation (for new features or changed behavior)
