### PR TITLE
PHP 8.1: Add return type int to Steps::count()

### DIFF
--- a/src/Step/Steps.php
+++ b/src/Step/Steps.php
@@ -106,7 +106,7 @@ final class Steps implements PostProcessStep, \Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->steps->count();
     }


### PR DESCRIPTION
## Description
Adds a return type `int` to `Steps::count()` to become compatible with `Countable::count(): int`

Fixes #114