### PR TITLE
Fix typo in `wp-config.php`

### DIFF
--- a/templates/wp-config.php
+++ b/templates/wp-config.php
@@ -303,7 +303,7 @@ CLEAN_UP : {
 
 ###################################################################################################
 #  I've seen things you people wouldn't believe. Attack ships on fire off the shoulder of Orion.  #
-#                 I watched C-beams glitter in the dark near the Tannhauser gate.                 #
+#                 I watched C-beams glitter in the dark near the Tannhäuser Gate.                 #
 #            All those moments will be lost in time, like tears in rain. Time to die.             #
 ###################################################################################################
 


### PR DESCRIPTION
## Description

Fix a typo in the "Tears in rain monologue". Source: https://en.wikipedia.org/wiki/Tears_in_rain_monologue

"Tannhauser gate" -> "Tannhäuser Gate"