### PR TITLE
Fix: env-bootstrap-dir doesn't work

### DIFF
--- a/templates/wp-config.php
+++ b/templates/wp-config.php
@@ -97,15 +97,15 @@ ENV_VARIABLES: {
 
     unset($envCacheEnabled, $envIsCached);
 
-    $phpEnvFilePath = WPSTARTER_PATH . "/{$envType}.php";
+    $phpEnvFilePath = realpath(__DIR__ . "{{{ENV_BOOTSTRAP_DIR}}}/{$envType}.php");
     $hasPhpEnvFile = file_exists($phpEnvFilePath) && is_readable($phpEnvFilePath);
     if ($hasPhpEnvFile) {
-        require_once WPSTARTER_PATH . "/{$envType}.php";
+        require_once $phpEnvFilePath;
     }
     $debugInfo['env-php-file'] = [
         'label' => 'Env-specific PHP file',
-        'value' => $hasPhpEnvFile ? WPSTARTER_PATH . "/{$envType}.php" : 'None',
-        'debug' => $hasPhpEnvFile ? WPSTARTER_PATH . "/{$envType}.php" : '',
+        'value' => $hasPhpEnvFile ? $phpEnvFilePath : 'None',
+        'debug' => $hasPhpEnvFile ? $phpEnvFilePath : '',
     ];
     unset($phpEnvFilePath, $hasPhpEnvFile);
 } #@@/ENV_VARIABLES


### PR DESCRIPTION
## Description

The `env-bootstrap-dir` option doesn't work.

## How has this been tested?

Manually. I didn't find appropriate tests for this.

## Types of changes

I changed the `templates/wp-config.php` file

## Checklist:
- [x] My code is tested
- [x] My code follows the project code style
- [ ] My code has documentation (for new features or changed behavior)
