### PR TITLE
MuLoaderStep should probably not hardcode build target file name

### DIFF
--- a/src/Step/MuLoaderStep.php
+++ b/src/Step/MuLoaderStep.php
@@ -110,7 +110,7 @@ final class MuLoaderStep implements FileCreationStepInterface
 
         $built = $this->builder->build(
             $paths,
-            'wpstarter-mu-loader.php',
+            self::TARGET_FILE_NAME,
             ['MU_PLUGINS_LIST' => implode(', ', $muPluginsPaths)]
         );
 


### PR DESCRIPTION
## Description
PR title.

## How has this been tested?
Executed `./composer wpstarter build-mu-loader`, result:

```
- [OK] MU plugin loader saved successfully.
```

## Checklist:
- [x] My code is tested
- [x] My code follows the project code style
- [x] My code has documentation (for new features or changed behavior)
