### PR TITLE
Bump symfony/dotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,16 +38,16 @@
         "ext-SPL": "*",
         "composer-plugin-api": "^1.10 || ^2",
         "composer/installers": "^1.12.0 || ^2",
-        "symfony/dotenv": "^3.4 || ^5 || ^6"
+        "symfony/dotenv": "^3.4 || ^5 || ^6 || ^7"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "composer/package-versions-deprecated": "^1.11.99",
         "composer/composer": "^2.5.4",
-        "symfony/process": "^3.4.47 || ^5.4.19",
+        "symfony/process": "^3.4.47 || ^5.4.19 || ^6 || ^7",
         "wp-cli/wp-cli": "^2.7.1",
         "inpsyde/php-coding-standards": "^1.0.0",
-        "vimeo/psalm": "^4.30.0",
+        "vimeo/psalm": "^4.30.0 || ^5",
         "phpunit/phpunit": "^7.5.20 || ^9.6.3",
         "mockery/mockery": "^1.3.6",
         "mikey179/vfsstream": "^1.6.11"


### PR DESCRIPTION
## Description

At first, I just wanted to bump symfony/dotenv to 7 for users that are on PHP 8.2.

However, some dev dependencies got symfony/dotenv stuck at 6.4.4.

So I bumped them too (vimeo/psalm & symfony/process) to allow symfony/dotenv 7 upgrade.

## How has this been tested?

Using your QA workflow here:
https://github.com/nlemoine/wpstarter/actions/runs/8214878478

All unit tests pass.

## Types of changes

No noticeable change on the code perspective. But bumping Pslam to the lastest version triggered many errors, which in the end might not be a bad thing. I guess the tool improved over time and spotted more potential errors.

## Checklist:
- [ ] My code is tested
- [ ] My code follows the project code style
- [ ] My code has documentation (for new features or changed behavior)
