### PR TITLE
Fix `wpstarter.skip-cache-env` arguments

### DIFF
--- a/src/Env/Helpers.php
+++ b/src/Env/Helpers.php
@@ -131,7 +131,7 @@ abstract class Helpers
             if (!did_action('plugins_loaded')) {
                 return !$skip;
             }
-            static::$shouldCache = !apply_filters('wpstarter.skip-cache-env', $skip);
+            static::$shouldCache = !apply_filters('wpstarter.skip-cache-env', $skip, $env);
         }
 
         return static::$shouldCache;


### PR DESCRIPTION
## Description

Missing `$env` type argument in `Helpers::shouldCacheEnv()`

## How has this been tested?

Locally. No unit tests seems to be there for the Helpers class yet.

## Types of changes

Fix

### Bug fixes (non-breaking change which fixes an issue)

Fix `wpstarter.skip-cache-env` arguments

## Issues
Which issue(s) this PR is addressing?

## Checklist:
- [ ] My code is tested
- [ ] My code follows the project code style
- [ ] My code has documentation (for new features or changed behavior)
