### PR TITLE
fix: Use valid code to trick WP-CLI 2.12+

### DIFF
--- a/templates/wp-config-loader.php
+++ b/templates/wp-config-loader.php
@@ -23,7 +23,7 @@ Ob-la-di, ob-la-da (la, la, la, la, la, la)
 Life goes on, brah (la, la, la, la, la, la)
 La, la, how the life goes on.
 
-require wp-settings.php
+require 'wp-settings.php';
 */
 
 const WP_STARTER_WP_CONFIG_PATH = __DIR__ . '{{{WP_CONFIG_PATH}}}';


### PR DESCRIPTION
## Description

The latest WP-CLI version isn't tricked so easily anymore by singing "ob-la-di, ob-la-da life goes on, brah" 🙂

https://github.com/wecodemore/wpstarter/blob/6ff8cab2003e9b6a4bd54a7ebcfd23ad27d521d4/templates/wp-config-loader.php#L13-L27

It now triggers an error:
````
Error: Strange wp-config.php file: wp-settings.php is not loaded directly.
````

See the relevant PR:s
- https://github.com/wp-cli/wp-cli/pull/6039
- https://github.com/wp-cli/wp-cli/pull/6042

The checks against `require wp-settings.php` have been enforced so its now needs to actual valid code.

## How has this been tested?

Locally using WP-CLI 2.12.

## Types of changes

A tiny change in `wp-config` PHP comment.

### Bug fixes (non-breaking change which fixes an issue)
- Fixes WP-CLI 2.12 compatibility
 
## Checklist:
- [x] My code is tested
- [x] My code follows the project code style
- [ ] My code has documentation (for new features or changed behavior)
