### PR TITLE
PHP 8.5: SplObjectStorage::attach() is deprecated, use ::offsetSet()

### DIFF
--- a/src/Step/Steps.php
+++ b/src/Step/Steps.php
@@ -106,9 +106,9 @@ final class Steps implements PostProcessStep, \Countable
     public function addStep(Step $step, Step ...$steps): Steps
     {
         if (!$this->running || ($this->runningScripts === 'pre')) {
-            $this->steps->attach($step);
+            $this->steps->offsetSet($step);
             foreach ($steps as $aStep) {
-                $this->steps->attach($aStep);
+                $this->steps->offsetSet($aStep);
             }
         }
 
@@ -251,7 +251,7 @@ final class Steps implements PostProcessStep, \Countable
                 $storage = new \SplObjectStorage();
                 $this->postProcessSteps = $storage;
             }
-            $this->postProcessSteps->attach($step);
+            $this->postProcessSteps->offsetSet($step);
         }
 
         if (!$this->shouldProcess($step, $paths, $io)) {


### PR DESCRIPTION
## Description

Fixes #144 

> Method SplObjectStorage::attach() is deprecated since 8.5, use method SplObjectStorage::offsetSet() instead

> SplObjectStorage::offsetSet() is an alias of SplObjectStorage::attach().


