### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ By cloning the repository and running:
 ./vendor/bin/phpcs
 ```
 
-it is possible to check code is compliant via [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer).
+it is possible to check code is compliant via [PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 
 Be sure to install Composer dependencies first.
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932